### PR TITLE
Get bluetooth working on MBP13,3

### DIFF
--- a/drivers/bluetooth/hci_bcm.c
+++ b/drivers/bluetooth/hci_bcm.c
@@ -359,7 +359,8 @@ static int bcm_open(struct hci_uart *hu)
 		 * platform device (saved during device probe) and
 		 * parent of tty device used by hci_uart
 		 */
-		if (hu->tty->dev->parent == dev->pdev->dev.parent) {
+		if (hu->tty->dev->parent == dev->pdev->dev.parent ||
+		    hu->tty->dev->parent->parent == dev->pdev->dev.parent) {
 			bcm->dev = dev;
 			hu->init_speed = dev->init_speed;
 			hu->oper_speed = dev->oper_speed;

--- a/drivers/bluetooth/hci_bcm.c
+++ b/drivers/bluetooth/hci_bcm.c
@@ -86,14 +86,14 @@ static LIST_HEAD(bcm_device_list);
 #ifdef CONFIG_ACPI
 static int bcm_apple_set_power(struct bcm_device *dev, bool enable)
 {
-	return ACPI_SUCCESS(acpi_evaluate_object(enable ? dev->btpu : dev->btpd,
+	return ACPI_FAILURE(acpi_evaluate_object(enable ? dev->btpu : dev->btpd,
 						 NULL, NULL, NULL));
 }
 
 static int bcm_apple_set_device_wake(struct bcm_device *dev, bool enable)
 {
-	return ACPI_SUCCESS(acpi_execute_simple_method(dev->btlp,
-						       NULL, enable));
+	return ACPI_FAILURE(acpi_execute_simple_method(dev->btlp,
+						       NULL, enable ? 0 : 1));
 }
 
 static bool bcm_apple_probe(struct bcm_device *dev)

--- a/drivers/bluetooth/hci_bcm.c
+++ b/drivers/bluetooth/hci_bcm.c
@@ -104,7 +104,8 @@ static bool bcm_apple_probe(struct bcm_device *dev)
 
 	if (!acpi_dev_get_property(adev, "baud", ACPI_TYPE_BUFFER, &obj) &&
 	    obj->buffer.length == 8) {
-		dev->oper_speed = *(u64 *)obj->buffer.pointer;
+		dev->init_speed = *(u64 *)obj->buffer.pointer;
+		dev->oper_speed = dev->init_speed;
 		dev_info(&dev->pdev->dev, "oper_speed=%u\n", dev->oper_speed);
 	}
 

--- a/drivers/bluetooth/hci_ldisc.c
+++ b/drivers/bluetooth/hci_ldisc.c
@@ -114,12 +114,12 @@ static inline struct sk_buff *hci_uart_dequeue(struct hci_uart *hu)
 	struct sk_buff *skb = hu->tx_skb;
 
 	if (!skb) {
-		read_lock(&hu->proto_lock);
+		percpu_down_read(&hu->proto_lock);
 
 		if (test_bit(HCI_UART_PROTO_READY, &hu->flags))
 			skb = hu->proto->dequeue(hu);
 
-		read_unlock(&hu->proto_lock);
+		percpu_up_read(&hu->proto_lock);
 	} else {
 		hu->tx_skb = NULL;
 	}
@@ -129,8 +129,6 @@ static inline struct sk_buff *hci_uart_dequeue(struct hci_uart *hu)
 
 int hci_uart_tx_wakeup(struct hci_uart *hu)
 {
-	read_lock(&hu->proto_lock);
-
 	if (!test_bit(HCI_UART_PROTO_READY, &hu->flags))
 		goto no_schedule;
 
@@ -144,8 +142,6 @@ int hci_uart_tx_wakeup(struct hci_uart *hu)
 	schedule_work(&hu->write_work);
 
 no_schedule:
-	read_unlock(&hu->proto_lock);
-
 	return 0;
 }
 EXPORT_SYMBOL_GPL(hci_uart_tx_wakeup);
@@ -246,12 +242,12 @@ static int hci_uart_flush(struct hci_dev *hdev)
 	tty_ldisc_flush(tty);
 	tty_driver_flush_buffer(tty);
 
-	read_lock(&hu->proto_lock);
+	percpu_down_read(&hu->proto_lock);
 
 	if (test_bit(HCI_UART_PROTO_READY, &hu->flags))
 		hu->proto->flush(hu);
 
-	read_unlock(&hu->proto_lock);
+	percpu_up_read(&hu->proto_lock);
 
 	return 0;
 }
@@ -274,15 +270,15 @@ static int hci_uart_send_frame(struct hci_dev *hdev, struct sk_buff *skb)
 	BT_DBG("%s: type %d len %d", hdev->name, hci_skb_pkt_type(skb),
 	       skb->len);
 
-	read_lock(&hu->proto_lock);
+	percpu_down_read(&hu->proto_lock);
 
 	if (!test_bit(HCI_UART_PROTO_READY, &hu->flags)) {
-		read_unlock(&hu->proto_lock);
+		percpu_up_read(&hu->proto_lock);
 		return -EUNATCH;
 	}
 
 	hu->proto->enqueue(hu, skb);
-	read_unlock(&hu->proto_lock);
+	percpu_up_read(&hu->proto_lock);
 
 	hci_uart_tx_wakeup(hu);
 
@@ -478,7 +474,7 @@ static int hci_uart_tty_open(struct tty_struct *tty)
 	INIT_WORK(&hu->init_ready, hci_uart_init_work);
 	INIT_WORK(&hu->write_work, hci_uart_write_work);
 
-	rwlock_init(&hu->proto_lock);
+	percpu_init_rwsem(&hu->proto_lock);
 
 	/* Flush any pending characters in the driver */
 	tty_driver_flush_buffer(tty);
@@ -495,7 +491,6 @@ static void hci_uart_tty_close(struct tty_struct *tty)
 {
 	struct hci_uart *hu = tty->disc_data;
 	struct hci_dev *hdev;
-	unsigned long flags;
 
 	BT_DBG("tty %p", tty);
 
@@ -512,9 +507,9 @@ static void hci_uart_tty_close(struct tty_struct *tty)
 	cancel_work_sync(&hu->write_work);
 
 	if (test_bit(HCI_UART_PROTO_READY, &hu->flags)) {
-		write_lock_irqsave(&hu->proto_lock, flags);
+		percpu_down_write(&hu->proto_lock);
 		clear_bit(HCI_UART_PROTO_READY, &hu->flags);
-		write_unlock_irqrestore(&hu->proto_lock, flags);
+		percpu_up_write(&hu->proto_lock);
 
 		if (hdev) {
 			if (test_bit(HCI_UART_REGISTERED, &hu->flags))
@@ -574,10 +569,10 @@ static void hci_uart_tty_receive(struct tty_struct *tty, const u8 *data,
 	if (!hu || tty != hu->tty)
 		return;
 
-	read_lock(&hu->proto_lock);
+	percpu_down_read(&hu->proto_lock);
 
 	if (!test_bit(HCI_UART_PROTO_READY, &hu->flags)) {
-		read_unlock(&hu->proto_lock);
+		percpu_up_read(&hu->proto_lock);
 		return;
 	}
 
@@ -585,7 +580,7 @@ static void hci_uart_tty_receive(struct tty_struct *tty, const u8 *data,
 	 * tty caller
 	 */
 	hu->proto->recv(hu, data, count);
-	read_unlock(&hu->proto_lock);
+	percpu_up_read(&hu->proto_lock);
 
 	if (hu->hdev)
 		hu->hdev->stat.byte_rx += count;

--- a/drivers/bluetooth/hci_uart.h
+++ b/drivers/bluetooth/hci_uart.h
@@ -87,7 +87,7 @@ struct hci_uart {
 	struct work_struct	write_work;
 
 	const struct hci_uart_proto *proto;
-	rwlock_t		proto_lock;	/* Stop work for proto close */
+	struct percpu_rw_semaphore proto_lock;	/* Stop work for proto close */
 	void			*priv;
 
 	struct sk_buff		*tx_skb;


### PR DESCRIPTION
The main two issues were the timing out of operations due to wrong baudrate (2nd commit) and not finding the UART (3rd commit). Things work reasonably well with this, though I still occasionally see a timeout on the first command, necessitating a re-attach of the tty.

I still see the following error when attaching the tty:
```
 Bluetooth: hci0: BCM: failed to write update baudrate (-16)   (-EBUSY)
```
But it is benign, as the UART device does not appear to need its baud rate changed.

Finally, the 4th commit fixes the following two BUG's:
```
 BUG: sleeping function called from invalid context at kernel/locking/mutex.c
 in_atomic(): 1, irqs_disabled(): 0, pid: 7303, name: kworker/7:3
 INFO: lockdep is turned off.
 CPU: 7 PID: 7303 Comm: kworker/7:3 Tainted: G        W  OE   4.13.2+ #17
 Hardware name: Apple Inc. MacBookPro13,3/Mac-A5C67F76ED83108C, BIOS MBP133.8
 Workqueue: events hci_uart_write_work [hci_uart]
 Call Trace:
  dump_stack+0x8e/0xd6
  ___might_sleep+0x164/0x250
  __might_sleep+0x4a/0x80
  __mutex_lock+0x59/0xa00
  ? lock_acquire+0xa3/0x1f0
  ? lock_acquire+0xa3/0x1f0
  ? hci_uart_write_work+0xd3/0x160 [hci_uart]
  mutex_lock_nested+0x1b/0x20
  ? mutex_lock_nested+0x1b/0x20
  bcm_dequeue+0x21/0xc0 [hci_uart]
  hci_uart_write_work+0xe6/0x160 [hci_uart]
  process_one_work+0x253/0x6a0
  worker_thread+0x4d/0x3b0
  kthread+0x133/0x150
  ? process_one_work+0x6a0/0x6a0
  ? kthread_create_on_node+0x70/0x70
  ret_from_fork+0x2a/0x40
```
--------------------------------------------------------------------------------
```
 BUG: sleeping function called from invalid context at kernel/locking/mutex.c
 in_atomic(): 1, irqs_disabled(): 0, pid: 13796, name: kworker/u16:2
 INFO: lockdep is turned off.
 CPU: 1 PID: 13796 Comm: kworker/u16:2 Tainted: G        W  OE   4.13.2+ #17
 Hardware name: Apple Inc. MacBookPro13,3/Mac-A5C67F76ED83108C, BIOS MBP133.8
 Workqueue: events_unbound flush_to_ldisc
 Call Trace:
  dump_stack+0x8e/0xd6
  ___might_sleep+0x164/0x250
  __might_sleep+0x4a/0x80
  __mutex_lock+0x59/0xa00
  ? trace_hardirqs_on+0xd/0x10
  ? hci_recv_frame+0x68/0xa0 [bluetooth]
  ? h4_recv_buf+0x17a/0x2f0 [hci_uart]
  mutex_lock_nested+0x1b/0x20
  ? mutex_lock_nested+0x1b/0x20
  bcm_recv+0x73/0x130 [hci_uart]
  hci_uart_tty_receive+0x61/0xa0 [hci_uart]
  tty_ldisc_receive_buf+0x48/0x50
  tty_port_default_receive_buf+0x49/0x70
  flush_to_ldisc+0x83/0xa0
  process_one_work+0x253/0x6a0
  worker_thread+0x4d/0x3b0
  kthread+0x133/0x150
  ? process_one_work+0x6a0/0x6a0
  ? kthread_create_on_node+0x70/0x70
  ret_from_fork+0x2a/0x40
```