### PR TITLE
PCI/CMA: Fixup init race

### DIFF
--- a/drivers/pci/cma.c
+++ b/drivers/pci/cma.c
@@ -59,6 +59,11 @@ void pci_cma_init(struct pci_dev *pdev)
 	if (!doe)
 		return;
 
+	if (!pci_cma_keyring) {
+		pr_err("Keyring not initialized");
+		return;
+	}
+
 	pdev->spdm_state = spdm_create(&pdev->dev, pci_doe_transport, doe,
 				       PCI_DOE_MAX_PAYLOAD, pci_cma_keyring,
 				       pci_cma_validate);
@@ -143,9 +148,11 @@ __init static int pci_cma_keyring_init(void)
 					KEY_USR_WRITE | KEY_USR_SEARCH,
 					KEY_ALLOC_NOT_IN_QUOTA |
 					KEY_ALLOC_SET_KEEP, NULL, NULL);
-	if (IS_ERR(pci_cma_keyring))
+	if (IS_ERR(pci_cma_keyring)) {
 		pr_err("Could not allocate keyring\n");
+		return PTR_ERR(pci_cma_keyring);
+	}
 
 	return 0;
 }
-device_initcall(pci_cma_keyring_init);
+subsys_initcall(pci_cma_keyring_init);


### PR DESCRIPTION
When `device_initcall()` is used to invoke `pci_cma_keyring_init()`, there exists a race between `pci_cma_keyring_init()` and `pci_cma_init()`. Running through QEMU, `pci_cma_init()` is always called first and thus eventually leads to a NULL ptr de-reference as `spdm_create()` is called before `pci_cma_keyring` is initialized (setting keyring to NULL in the spdm state).

Change `device_initcall` to `subsys_initcall`, to make sure pci_cma_keyring_init is prioritized.

Notes:
Is it safe to use `subsys_init()` here? Alternatively, couldn't `pci_cma_keyring_init()` just be called within `pci_cma_keyring_init()`? 